### PR TITLE
롤링페이퍼에 메세지 보내기 페이지 (/post/{id}/message)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-quill": "^2.0.0",
     "react-router-dom": "^6.22.3",
     "styled-components": "^6.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-quill:
+    specifier: ^2.0.0
+    version: 2.0.0(react-dom@18.2.0)(react@18.2.0)
   react-router-dom:
     specifier: ^6.22.3
     version: 6.22.3(react-dom@18.2.0)(react@18.2.0)
@@ -837,6 +840,12 @@ packages:
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
     dev: true
 
+  /@types/quill@1.3.10:
+    resolution: {integrity: sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==}
+    dependencies:
+      parchment: 1.1.4
+    dev: false
+
   /@types/react-dom@18.2.24:
     resolution: {integrity: sha512-cN6upcKd8zkGy4HU9F1+/s98Hrp6D4MOcippK4PoE8OZRngohHZpbJn1GsaDLz87MqvHNoT13nHvNqM9ocRHZg==}
     dependencies:
@@ -1346,7 +1355,6 @@ packages:
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
-    dev: true
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1389,6 +1397,11 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
     dev: true
+
+  /clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+    dev: false
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -1509,6 +1522,18 @@ packages:
       ms: 2.1.2
     dev: true
 
+  /deep-equal@1.1.2:
+    resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      is-arguments: 1.1.1
+      is-date-object: 1.0.5
+      is-regex: 1.1.4
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      regexp.prototype.flags: 1.5.2
+    dev: false
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -1520,7 +1545,6 @@ packages:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
-    dev: true
 
   /define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -1529,7 +1553,6 @@ packages:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    dev: true
 
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1646,12 +1669,10 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       get-intrinsic: 1.2.4
-    dev: true
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /es-iterator-helpers@1.0.18:
     resolution: {integrity: sha512-scxAJaewsahbqTYrGKJihhViaM6DDZDDoucfvzNbK0pOren1g/daDQ3IAhzn+1G14rBG7w+i5N+qul60++zlKA==}
@@ -2161,9 +2182,21 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /eventemitter3@2.0.3:
+    resolution: {integrity: sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==}
+    dev: false
+
+  /extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
+
+  /fast-diff@1.1.2:
+    resolution: {integrity: sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==}
+    dev: false
 
   /fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -2253,7 +2286,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: true
 
   /function.prototype.name@1.1.6:
     resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
@@ -2267,7 +2299,6 @@ packages:
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-    dev: true
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2283,7 +2314,6 @@ packages:
       has-proto: 1.0.3
       has-symbols: 1.0.3
       hasown: 2.0.2
-    dev: true
 
   /get-stdin@9.0.0:
     resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
@@ -2380,7 +2410,6 @@ packages:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
       get-intrinsic: 1.2.4
-    dev: true
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2408,31 +2437,26 @@ packages:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
     dependencies:
       es-define-property: 1.0.0
-    dev: true
 
   /has-proto@1.0.3:
     resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
-    dev: true
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: true
 
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -2480,6 +2504,14 @@ packages:
       hasown: 2.0.2
       side-channel: 1.0.6
     dev: true
+
+  /is-arguments@1.1.1:
+    resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      has-tostringtag: 1.0.2
+    dev: false
 
   /is-array-buffer@3.0.4:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
@@ -2544,7 +2576,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.2
-    dev: true
 
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2609,7 +2640,6 @@ packages:
     dependencies:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
-    dev: true
 
   /is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -2798,6 +2828,10 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+    dev: false
+
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2887,10 +2921,17 @@ packages:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
     dev: true
 
+  /object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+    dev: false
+
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /object.assign@4.1.5:
     resolution: {integrity: sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==}
@@ -2998,6 +3039,10 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
     dev: true
+
+  /parchment@1.1.4:
+    resolution: {integrity: sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==}
+    dev: false
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3121,6 +3166,26 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /quill-delta@3.6.3:
+    resolution: {integrity: sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      deep-equal: 1.1.2
+      extend: 3.0.2
+      fast-diff: 1.1.2
+    dev: false
+
+  /quill@1.3.7:
+    resolution: {integrity: sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==}
+    dependencies:
+      clone: 2.1.2
+      deep-equal: 1.1.2
+      eventemitter3: 2.0.3
+      extend: 3.0.2
+      parchment: 1.1.4
+      quill-delta: 3.6.3
+    dev: false
+
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -3134,6 +3199,19 @@ packages:
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: true
+
+  /react-quill@2.0.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==}
+    peerDependencies:
+      react: ^16 || ^17 || ^18
+      react-dom: ^16 || ^17 || ^18
+    dependencies:
+      '@types/quill': 1.3.10
+      lodash: 4.17.21
+      quill: 1.3.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
@@ -3219,7 +3297,6 @@ packages:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
-    dev: true
 
   /regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
@@ -3358,7 +3435,6 @@ packages:
       get-intrinsic: 1.2.4
       gopd: 1.0.1
       has-property-descriptors: 1.0.2
-    dev: true
 
   /set-function-name@2.0.2:
     resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
@@ -3368,7 +3444,6 @@ packages:
       es-errors: 1.3.0
       functions-have-names: 1.2.3
       has-property-descriptors: 1.0.2
-    dev: true
 
   /shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}

--- a/src/Main.jsx
+++ b/src/Main.jsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { App } from "./components/App";
 import { HomePage } from "./pages/HomePage";
 import { ListPage } from "./pages/ListPage";
-import { MessageCreatePage } from "./pages/MessageCreatePage";
+import { MessageCreatePage } from "./pages/MessageCreatePage/MessageCreatePage";
 import { PostCreatePage } from "./pages/PostCreatePage";
 import { PostPage } from "./pages/PostPage";
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,36 +1,36 @@
 export const API_INFO = {
-  baseUrl: 'https://rolling-api.vercel.app',
+  baseUrl: "https://rolling-api.vercel.app",
   endPoints: {
-    getBackgroundImages: { url: '/background-images/', method: 'GET' },
-    getProfileImages: { url: '/profile-images/', method: 'GET' },
+    getBackgroundImages: { url: "/background-images/", method: "GET" },
+    getProfileImages: { url: "/profile-images/", method: "GET" },
 
     //messages
-    getMessages: { url: '/10/messages/{param1}/', method: 'GET' },
-    putMessages: { url: '/10/messages/{param1}/', method: 'PUT' },
-    patchMessages: { url: '/10/messages/{param1}/', method: 'PATCH' },
-    deleteMessages: { url: '/10/messages/{param1}/', method: 'DELETE' },
+    getMessages: { url: "/5-10/messages/{param1}/", method: "GET" },
+    putMessages: { url: "/5-10/messages/{param1}/", method: "PUT" },
+    patchMessages: { url: "/5-10/messages/{param1}/", method: "PATCH" },
+    deleteMessages: { url: "/5-10/messages/{param1}/", method: "DELETE" },
 
     //recipients
-    getRecipients: { url: '/10/recipients/', method: 'GET' },
-    postRecipients: { url: '/10/recipients/', method: 'POST' },
-    getRecipientsById: { url: '/10/recipients/{param1}/', method: 'GET' },
-    deleteRecipients: { url: '/10/recipients/{param1}/', method: 'DELETE' },
+    getRecipients: { url: "/5-10/recipients/", method: "GET" },
+    postRecipients: { url: "/5-10/recipients/", method: "POST" },
+    getRecipientsById: { url: "/5-10/recipients/{param1}/", method: "GET" },
+    deleteRecipients: { url: "/5-10/recipients/{param1}/", method: "DELETE" },
 
     getRecipientsMessages: {
-      url: '/10/recipients/{param1}/messages/',
-      method: 'GET',
+      url: "/5-10/recipients/{param1}/messages/",
+      method: "GET",
     },
     postRecipientsMessages: {
-      url: '/10/recipients/{param1}/messages/',
-      method: 'POST',
+      url: "/5-10/recipients/{param1}/messages/",
+      method: "POST",
     },
     getRecipientsReactions: {
-      url: '/10/recipients/{param1}/reactions/',
-      method: 'GET',
+      url: "/5-10/recipients/{param1}/reactions/",
+      method: "GET",
     },
     postRecipientsReactions: {
-      url: '/10/recipients/{param1}/reactions/',
-      method: 'POST',
+      url: "/5-10/recipients/{param1}/reactions/",
+      method: "POST",
     },
   },
 };

--- a/src/pages/MessageCreatePage.jsx
+++ b/src/pages/MessageCreatePage.jsx
@@ -1,7 +1,0 @@
-export function MessageCreatePage() {
-  return (
-    <>
-      <div>{`Hi I'm MessageCreatePage`}</div>
-    </>
-  )
-}

--- a/src/pages/MessageCreatePage/Form.jsx
+++ b/src/pages/MessageCreatePage/Form.jsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import { API_INFO, putParams } from "../../api/api";
 import { useApi, useFetch } from "../../hooks/useFetch";
-import { Bold18, Bold24, Regular16 } from "../../styles/FontStyle";
+import { Bold18, Bold24, Regular12, Regular16 } from "../../styles/FontStyle";
 import { TextEditor } from "./TextEditor";
 
 const StyledForm = styled.form`
@@ -47,6 +47,12 @@ const Input = styled.input`
   &::placeholder {
     color: var(--gray500);
   }
+`;
+
+const ErrorMessage = styled.p`
+  ${Regular12};
+  color: var(--error);
+  margin-top: -8px;
 `;
 
 const Select = styled.select`
@@ -134,6 +140,7 @@ export function Form() {
   const defaultImg = data?.imageUrls[0];
 
   const [values, setValues] = useState(INITIAL_VALUES);
+  const [error, setError] = useState(false);
   const [content, setContent] = useState("");
   const [isEmpty, setIsEmpty] = useState(true);
 
@@ -152,6 +159,15 @@ export function Form() {
   function handleInputChange(e) {
     const { name, value } = e.target;
     handleChange(name, value);
+  }
+  
+  function handleErrorMessage(e) {
+    const { value } = e.target;
+    if (!value) {
+      setError(true);
+    } else {
+      setError(false);
+    }
   }
 
   function handleProfileImg(e) {
@@ -199,11 +215,14 @@ export function Form() {
       <FormContent>
         <Label htmlFor="sender">From.</Label>
         <Input
+          style={{ border: error && "1px solid var(--error)" }}
           name="sender"
           placeholder="이름을 입력해 주세요."
           value={values.sender}
           onChange={handleInputChange}
+          onBlur={handleErrorMessage}
         />
+        <ErrorMessage>{error ? "값을 입력해 주세요." : ""}</ErrorMessage>
       </FormContent>
 
       <FormContent>
@@ -218,9 +237,9 @@ export function Form() {
         >
           {values.img && <ProfileImg src={values.img} alt="이미지 미리보기" />}
 
-          {(values.img !== "") && (values.img !== defaultImg) && 
+          {values.img !== "" && values.img !== defaultImg && (
             <ResetButton onClick={handleClearClick}>X</ResetButton>
-          }
+          )}
 
           <div
             style={{

--- a/src/pages/MessageCreatePage/Form.jsx
+++ b/src/pages/MessageCreatePage/Form.jsx
@@ -1,0 +1,296 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import styled from "styled-components";
+import { API_INFO, putParams } from "../../api/api";
+import { useApi, useFetch } from "../../hooks/useFetch";
+import { Bold18, Bold24, Regular16 } from "../../styles/FontStyle";
+import { TextEditor } from "./TextEditor";
+
+const StyledForm = styled.form`
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 50px;
+
+  @media screen and (max-width: 768px) {
+    margin-left: 24px;
+    margin-right: 24px;
+    width: 100%;
+  }
+
+  @media screen and (max-width: 360px) {
+    margin-left: 20px;
+    margin-right: 20px;
+    width: 100%;
+  }
+`;
+
+const FormContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const Label = styled.label`
+  ${Bold24};
+  color: var(--gray900);
+`;
+
+const Input = styled.input`
+  padding: 12px 16px;
+  border-radius: 8px;
+  ${Regular16};
+  border: 1px solid var(--gray300);
+  color: var(--gray500);
+
+  &::placeholder {
+    color: var(--gray500);
+  }
+`;
+
+const Select = styled.select`
+  max-width: 50%;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--gray300);
+  ${Regular16};
+  color: var(--gray500);
+
+  @media screen and (max-width: 360px) {
+    max-width: 100%;
+  }
+`;
+
+const Submit = styled.input`
+  width: 100%;
+  padding: 14px 0;
+  border-radius: 12px;
+  ${Bold18};
+  border: 0;
+  color: var(--white);
+`;
+
+const ProfileImg = styled.img`
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 9999px;
+`;
+
+const ResetButton = styled.button`
+  position: absolute;
+  top: 1px;
+  left: 55px;
+  width: 25px;
+  height: 25px;
+  border-radius: 9999px;
+  border: 0.5px solid var(--white);
+  background-color: var(--gray600);
+  color: var(--white);
+
+  @media screen and (max-width: 360px) {
+    position: absolute;
+    top: 45px;
+    left: 55px;
+  }
+`;
+
+const ProfileImgOptionsLayout = styled.div`
+  display: block;
+`;
+
+const ProfileImgOptions = styled.img`
+  width: 54px;
+  height: 54px;
+  object-fit: cover;
+  border-radius: 9999px;
+  margin-right: 4px;
+  margin-bottom: 4px;
+
+  @media screen and (max-width: 360px) {
+    width: 40px;
+    height: 40px;
+    margin-right: 4px;
+    margin-bottom: 4px;
+  }
+`;
+
+const Description = styled.p`
+  ${Regular16};
+`;
+
+const INITIAL_VALUES = {
+  sender: "",
+  img: "",
+  relationship: "지인",
+  content: "",
+  font: "Noto Sans",
+};
+
+export function Form() {
+  const url = API_INFO.baseUrl + API_INFO.endPoints.getProfileImages.url;
+  const { data } = useFetch({ url });
+  const defaultImg = data?.imageUrls[0];
+
+  const [values, setValues] = useState(INITIAL_VALUES);
+  const [content, setContent] = useState("");
+  const [isEmpty, setIsEmpty] = useState(true);
+
+  const navigate = useNavigate();
+
+  const [sendRequest] = useApi();
+  const { postId } = useParams();
+
+  function handleChange(name, value) {
+    setValues((prevValues) => ({
+      ...prevValues,
+      [name]: value,
+    }));
+  }
+
+  function handleInputChange(e) {
+    const { name, value } = e.target;
+    handleChange(name, value);
+  }
+
+  function handleProfileImg(e) {
+    const { localName: name, currentSrc: value } = e.target;
+    handleChange(name, value);
+  }
+
+  function handleClearClick(e) {
+    const name = "img";
+    handleChange(name, defaultImg);
+  }
+
+  useEffect(() => {
+    const name = "content";
+    const value = content;
+    handleChange(name, value);
+  }, [content]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!(values.sender && !isEmpty)) return;
+
+    sendRequest({
+      url:
+        API_INFO.baseUrl +
+        putParams(API_INFO.endPoints.postRecipientsMessages.url, postId),
+      method: API_INFO.endPoints.postRecipientsMessages.method,
+      body: {
+        team: "5-10",
+        recipientId: postId,
+        sender: values.sender,
+        profileImageURL: values.img,
+        relationship: values.relationship,
+        content: values.content,
+        font: values.font,
+      },
+      callback: () => {
+        navigate(`/post/${postId}`);
+      },
+    });
+  };
+
+  return (
+    <StyledForm onSubmit={handleSubmit}>
+      <FormContent>
+        <Label htmlFor="sender">From.</Label>
+        <Input
+          name="sender"
+          placeholder="이름을 입력해 주세요."
+          value={values.sender}
+          onChange={handleInputChange}
+        />
+      </FormContent>
+
+      <FormContent>
+        <Label htmlFor="profile_img">프로필 이미지</Label>
+        <div
+          style={{
+            display: "flex",
+            gap: "32px",
+            alignItems: "center",
+            position: "relative",
+          }}
+        >
+          {values.img && <ProfileImg src={values.img} alt="이미지 미리보기" />}
+
+          {(values.img !== "") && (values.img !== defaultImg) && 
+            <ResetButton onClick={handleClearClick}>X</ResetButton>
+          }
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "space-between",
+              gap: "5px",
+            }}
+          >
+            <Description>프로필 이미지를 선택해주세요!</Description>
+            <ProfileImgOptionsLayout>
+              {data?.imageUrls.map(
+                (img, i) =>
+                  i !== 0 && (
+                    <ProfileImgOptions
+                      key={i}
+                      src={img}
+                      alt="프로필 이미지"
+                      onClick={handleProfileImg}
+                    />
+                  ),
+              )}
+            </ProfileImgOptionsLayout>
+          </div>
+        </div>
+      </FormContent>
+
+      <FormContent>
+        <Label htmlFor="relationship">상대와의 관계</Label>
+        <Select
+          name="relationship"
+          value={values.relationship}
+          onChange={handleInputChange}
+        >
+          <option value="지인">지인</option>
+          <option value="친구">친구</option>
+          <option value="동료">동료</option>
+          <option value="가족">가족</option>
+        </Select>
+      </FormContent>
+
+      <FormContent>
+        <Label htmlFor="content">내용을 입력해 주세요</Label>
+        <TextEditor
+          name="content"
+          value={content}
+          onChange={setContent}
+          setIsEmpty={setIsEmpty}
+        />
+      </FormContent>
+
+      <FormContent>
+        <Label htmlFor="font">폰트 선택</Label>
+        <Select name="font" value={values.font} onChange={handleInputChange}>
+          <option value="Noto Sans">Noto Sans</option>
+          <option value="Pretendard">Pretendard</option>
+          <option value="나눔명조">나눔명조</option>
+          <option value="나눔손글씨 손편지체">나눔손글씨 손편지체</option>
+        </Select>
+      </FormContent>
+
+      <Submit
+        style={{
+          marginTop: "12px",
+          backgroundColor:
+            values.sender && !isEmpty ? "var(--purple700)" : "var(--gray300)",
+        }}
+        type="submit"
+        value="생성하기"
+      />
+    </StyledForm>
+  );
+}

--- a/src/pages/MessageCreatePage/MessageCreatePage.jsx
+++ b/src/pages/MessageCreatePage/MessageCreatePage.jsx
@@ -1,0 +1,16 @@
+import { Form } from "./Form";
+
+export function MessageCreatePage() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "center",
+        marginTop: "47px",
+        marginBottom: "60px",
+      }}
+    >
+      <Form />
+    </div>
+  );
+}

--- a/src/pages/MessageCreatePage/TextEditor.jsx
+++ b/src/pages/MessageCreatePage/TextEditor.jsx
@@ -16,12 +16,16 @@ const modules = {
   },
 };
 
+function stripHTMLTags(str) {
+  return str.replace(/<[^>]+>/g, "");
+}
+
 const formats = ["header", "bold", "underline", "list", "bullet", "indent"];
 
 export function TextEditor({ value, onChange, setIsEmpty }) {
   const onEdit = (e) => {
     onChange(e);
-    if (e.replace("<p><br></p>", "").length === 0) {
+    if (stripHTMLTags(e) === '') {
       setIsEmpty(true);
     } else {
       setIsEmpty(false);

--- a/src/pages/MessageCreatePage/TextEditor.jsx
+++ b/src/pages/MessageCreatePage/TextEditor.jsx
@@ -1,0 +1,42 @@
+import ReactQuill from "react-quill";
+import "react-quill/dist/quill.snow.css";
+
+const modules = {
+  toolbar: {
+    container: [
+      [{ header: [1, 2, false] }],
+      ["bold", "underline"],
+      [
+        { list: "ordered" },
+        { list: "bullet" },
+        { indent: "-1" },
+        { indent: "+1" },
+      ],
+    ],
+  },
+};
+
+const formats = ["header", "bold", "underline", "list", "bullet", "indent"];
+
+export function TextEditor({ value, onChange, setIsEmpty }) {
+  const onEdit = (e) => {
+    onChange(e);
+    if (e.replace("<p><br></p>", "").length === 0) {
+      setIsEmpty(true);
+    } else {
+      setIsEmpty(false);
+    }
+  };
+
+  return (
+    <ReactQuill
+      style={{ height: "230px", marginBottom: "50px" }}
+      theme="snow"
+      placeholder="메세지를 남겨주세요."
+      modules={modules}
+      formats={formats}
+      value={value}
+      onChange={onEdit}
+    />
+  );
+}

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -88,7 +88,7 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
+  font-size: 10px;
   vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
namgyeonglee/feature/add-message-create-page -> main

### 변경 사항

- 롤링페이퍼에 메세지 보내기 페이지(/post/{id}/message) 레이아웃, css, 기능 구현
- [x] 'From.' Input 컴포넌트에 값을 입력하지 않고 focus out 하면, Input 컴포넌트를 에러 상태로 변경하고 “값을 입력해 주세요.” 에러 메세지가 보입니다.
- [x] 프로필 이미지 파일을 선택 하지 않으면 기본이미지를 넣습니다.
- [x] '상대와의 관계' 항목은 지인이 기본값으로 선택되어 있습니다. `친구” | “지인” | “동료” | “가족` 중에 하나를 고르셔야 합니다.
- [x] “내용을 입력해 주세요” 항목의 에디터는 예시입니다. 디자인과 기능을 고려해 외부 에디터 모듈을 사용해도 됩니다.
- [x] 폰트는 'Noto Sans'가 기본값으로 선택되어 있습니다.
- [x] '생성하기' 버튼은 비활성화 상태에 있다가 받는 사람 이름과 카드 내용이 있는 경우 활성화 됩니다.
- [x] '생성하기 버튼을 누르면 롤링페이퍼가 생성이 되고 `/post/{id}` 로 이동합니다.
- content 비었을 때 버튼 비활성화 기능) Quill Editor 에서 작성된 내용 중 html 태그 초기화 하는 코드 수정


### 테스트 결과

<img width="1384" alt="Screenshot 2024-04-17 at 2 47 38 PM" src="https://github.com/namgyeonglee/rolling/assets/110335540/0118539f-49b7-4160-be10-b83faa745935">

ㄴ POST 잘 작동합니다.
