### PR TITLE
fix: page별 nav > button 숨김기능

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import logo from "../assets/images/logo.svg";
 import rolling from "../assets/images/rolling.svg";
@@ -59,6 +59,11 @@ const StyledLink = styled(Link)`
   text-decoration: none;
 `;
 export function Nav() {
+  const location = useLocation();
+
+  const showMakeButton =
+    location.pathname === "/list" || location.pathname === "/" ? true : false;
+
   return (
     <StyledNav>
       <StyledGnb>
@@ -67,7 +72,7 @@ export function Nav() {
           <StyledLogo src={rolling} alt="rolling logo" />
         </StyledLink>
         <StyledLink to="/post">
-          <StyledButton>롤링 페이퍼 만들기</StyledButton>
+          {showMakeButton && <StyledButton>롤링 페이퍼 만들기</StyledButton>}
         </StyledLink>
       </StyledGnb>
     </StyledNav>


### PR DESCRIPTION
PR 타입
[x] 기능 추가
[ ] 기능 삭제
[ ] 버그 수정
[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

반영 브랜치
nayeon/main-page -> main

변경 사항
nav의 ‘롤링 페이퍼 만들기’ 버튼이 홈이랑 list 페이지 이외에는 안보이게 처리

테스트 결과