### PR TITLE
feat: create customizable select common component

### DIFF
--- a/src/assets/arrow_bottom.svg
+++ b/src/assets/arrow_bottom.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 4.76942L8 11.231L14 4.76942" stroke="#181818" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/arrow_top.svg
+++ b/src/assets/arrow_top.svg
@@ -1,0 +1,3 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.5 11.2306L8.5 4.76904L14.5 11.2306" stroke="#181818" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/MessageCreatePage/CustomSelect.jsx
+++ b/src/pages/MessageCreatePage/CustomSelect.jsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import styled from "styled-components";
+import arrowBottom from "../../assets/arrow_bottom.svg";
+import arrowTop from "../../assets/arrow_top.svg";
+import { Regular16 } from "../../styles/FontStyle";
+
+const SelectBox = styled.button`
+  width: 50%;
+  border: 1px solid var(--gray300);
+  border-radius: 8px;
+  padding: 12px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  ${Regular16};
+  color: var(--gray500);
+  background-color: var(--white);
+
+  &:hover,
+  &:focus {
+    border: 2px solid var(--gray500);
+  }
+
+  @media screen and (max-width: 360px) {
+    width: 100%;
+  }
+`;
+
+const Listbox = styled.ul`
+  background: var(--white);
+  position: absolute;
+  top: 60px;
+  left: 0;
+  width: 50%;
+  padding: 10px 0;
+  list-style: none;
+  border: 1px solid var(--gray300);
+  box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  overflow: hidden;
+
+  @media screen and (max-width: 360px) {
+    width: 100%;
+  }
+`;
+
+const List = styled.li`
+  background: var(--white);
+  border: none;
+  ${Regular16};
+  color: var(--gray900);
+  text-align: left;
+  padding: 12px 16px;
+
+  &:hover,
+  &:focus {
+    background: var(--gray100);
+    width: 100%;
+  }
+
+  @media screen and (max-width: 360px) {
+    width: 100%;
+  }
+`;
+
+export function CustomSelect({ value, onChange, options }) {
+  const [arrow, setArrow] = useState(arrowBottom);
+
+  function handleSelectBoxClick(e) {
+    e.preventDefault();
+    if (arrow === arrowBottom) {
+      setArrow(arrowTop);
+    } else {
+      setArrow(arrowBottom);
+    }
+  }
+
+  function handleSelectValue(selectedValue, e) {
+    e.preventDefault();
+    onChange(selectedValue);
+    handleSelectBoxClick(e);
+  }
+
+  return (
+    <div style={{ position: "relative", zIndex: "1" }}>
+      <SelectBox onClick={handleSelectBoxClick}>
+        {value}
+        <img src={arrow} alt="arrow" />
+      </SelectBox>
+      {arrow === arrowTop && (
+        <Listbox id="listbox">
+          {options.map((option, index) => (
+            <List
+              key={index}
+              value={option}
+              onClick={(e) => handleSelectValue(option, e)}
+            >
+              {option}
+            </List>
+          ))}
+        </Listbox>
+      )}
+    </div>
+  );
+}

--- a/src/pages/MessageCreatePage/CustomToolbar.jsx
+++ b/src/pages/MessageCreatePage/CustomToolbar.jsx
@@ -1,0 +1,26 @@
+export default function CustomToolbar() {
+  return (
+    <div
+      id="toolbar"
+      style={{
+        marginBottom: "-13px",
+        backgroundColor: "var(--gray100)",
+        border: "1px solid var(--gray300)",
+        borderTopLeftRadius: "8px",
+        borderTopRightRadius: "8px",
+      }}
+    >
+      <span className="ql-formats">
+        <select className="ql-header" defaultValue="3">
+          <option value="1">Header 1</option>
+          <option value="2">Header 2</option>
+          <option value="3">Normal</option>
+        </select>
+      </span>
+      <span className="ql-formats">
+        <button className="ql-bold" />
+        <button className="ql-underline" />
+      </span>
+    </div>
+  );
+}

--- a/src/pages/MessageCreatePage/Form.jsx
+++ b/src/pages/MessageCreatePage/Form.jsx
@@ -199,7 +199,7 @@ export function Form() {
         team: "5-10",
         recipientId: postId,
         sender: values.sender,
-        profileImageURL: values.img,
+        profileImageURL: values.img ? values.img : defaultImg,
         relationship: values.relationship,
         content: values.content,
         font: values.font,

--- a/src/pages/MessageCreatePage/Form.jsx
+++ b/src/pages/MessageCreatePage/Form.jsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { API_INFO, putParams } from "../../api/api";
 import { useApi } from "../../hooks/useApi";
 import { Bold18, Bold24, Regular12, Regular16 } from "../../styles/FontStyle";
+import { CustomSelect } from "./CustomSelect";
 import { TextEditor } from "./TextEditor";
 
 const StyledForm = styled.form`
@@ -126,22 +127,28 @@ const Description = styled.p`
   ${Regular16};
 `;
 
+const INITIAL_RELATIONSHIP_VALUE = "지인";
+const INITIAL_FONT_VALUE = "Noto Sans";
+
 const INITIAL_VALUES = {
   sender: "",
   img: "",
-  relationship: "지인",
+  relationship: INITIAL_RELATIONSHIP_VALUE,
   content: "",
-  font: "Noto Sans",
+  font: INITIAL_FONT_VALUE,
 };
 
+const url = API_INFO.baseUrl + API_INFO.endPoints.getProfileImages.url;
+
 export function Form() {
-  const url = API_INFO.baseUrl + API_INFO.endPoints.getProfileImages.url;
   const { data } = useApi({ url, immediate: true });
   const defaultImg = data?.imageUrls[0];
 
   const [values, setValues] = useState(INITIAL_VALUES);
   const [error, setError] = useState(false);
   const [content, setContent] = useState("");
+  const [relationship, setRelationship] = useState(INITIAL_RELATIONSHIP_VALUE);
+  const [font, setFont] = useState(INITIAL_FONT_VALUE);
   const [isEmpty, setIsEmpty] = useState(true);
 
   const navigate = useNavigate();
@@ -181,10 +188,16 @@ export function Form() {
   }
 
   useEffect(() => {
-    const name = "content";
-    const value = content;
-    handleChange(name, value);
+    handleChange("content", content);
   }, [content]);
+
+  useEffect(() => {
+    handleChange("relationship", relationship);
+  }, [relationship]);
+
+  useEffect(() => {
+    handleChange("font", font);
+  }, [font]);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -269,16 +282,12 @@ export function Form() {
 
       <FormContent>
         <Label htmlFor="relationship">상대와의 관계</Label>
-        <Select
+        <CustomSelect
           name="relationship"
-          value={values.relationship}
-          onChange={handleInputChange}
-        >
-          <option value="지인">지인</option>
-          <option value="친구">친구</option>
-          <option value="동료">동료</option>
-          <option value="가족">가족</option>
-        </Select>
+          value={relationship}
+          onChange={setRelationship}
+          options={["지인", "친구", "동료", "가족"]}
+        />
       </FormContent>
 
       <FormContent>
@@ -293,12 +302,17 @@ export function Form() {
 
       <FormContent>
         <Label htmlFor="font">폰트 선택</Label>
-        <Select name="font" value={values.font} onChange={handleInputChange}>
-          <option value="Noto Sans">Noto Sans</option>
-          <option value="Pretendard">Pretendard</option>
-          <option value="나눔명조">나눔명조</option>
-          <option value="나눔손글씨 손편지체">나눔손글씨 손편지체</option>
-        </Select>
+        <CustomSelect
+          name="font"
+          value={font}
+          onChange={setFont}
+          options={[
+            "Noto Sans",
+            "Pretendard",
+            "나눔명조",
+            "나눔손글씨 손편지체",
+          ]}
+        />
       </FormContent>
 
       <Submit

--- a/src/pages/MessageCreatePage/Form.jsx
+++ b/src/pages/MessageCreatePage/Form.jsx
@@ -42,8 +42,14 @@ const Input = styled.input`
   padding: 12px 16px;
   border-radius: 8px;
   ${Regular16};
+  outline: none;
   border: 1px solid var(--gray300);
   color: var(--gray500);
+
+  &:hover,
+  &:focus {
+    border: 2px solid var(--gray500);
+  }
 
   &::placeholder {
     color: var(--gray500);

--- a/src/pages/MessageCreatePage/Form.jsx
+++ b/src/pages/MessageCreatePage/Form.jsx
@@ -62,19 +62,6 @@ const ErrorMessage = styled.p`
   margin-top: -8px;
 `;
 
-const Select = styled.select`
-  max-width: 50%;
-  padding: 12px 16px;
-  border-radius: 8px;
-  border: 1px solid var(--gray300);
-  ${Regular16};
-  color: var(--gray500);
-
-  @media screen and (max-width: 360px) {
-    max-width: 100%;
-  }
-`;
-
 const Submit = styled.input`
   width: 100%;
   padding: 14px 0;

--- a/src/pages/MessageCreatePage/TextEditor.jsx
+++ b/src/pages/MessageCreatePage/TextEditor.jsx
@@ -17,7 +17,6 @@ function stripHTMLTags(str) {
 export function TextEditor({ value, onChange, setIsEmpty }) {
   const onEdit = (e) => {
     onChange(e);
-    console.log(e);
     if (stripHTMLTags(e) === "") {
       setIsEmpty(true);
     } else {

--- a/src/pages/MessageCreatePage/TextEditor.jsx
+++ b/src/pages/MessageCreatePage/TextEditor.jsx
@@ -1,31 +1,24 @@
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
+import CustomToolbar from "./CustomToolbar";
 
 const modules = {
   toolbar: {
-    container: [
-      [{ header: [1, 2, false] }],
-      ["bold", "underline"],
-      [
-        { list: "ordered" },
-        { list: "bullet" },
-        { indent: "-1" },
-        { indent: "+1" },
-      ],
-    ],
+    container: "#toolbar",
   },
 };
+
+const formats = ["header", "bold", "underline"];
 
 function stripHTMLTags(str) {
   return str.replace(/<[^>]+>/g, "");
 }
 
-const formats = ["header", "bold", "underline", "list", "bullet", "indent"];
-
 export function TextEditor({ value, onChange, setIsEmpty }) {
   const onEdit = (e) => {
     onChange(e);
-    if (stripHTMLTags(e) === '') {
+    console.log(e);
+    if (stripHTMLTags(e) === "") {
       setIsEmpty(true);
     } else {
       setIsEmpty(false);
@@ -33,14 +26,17 @@ export function TextEditor({ value, onChange, setIsEmpty }) {
   };
 
   return (
-    <ReactQuill
-      style={{ height: "230px", marginBottom: "50px" }}
-      theme="snow"
-      placeholder="메세지를 남겨주세요."
-      modules={modules}
-      formats={formats}
-      value={value}
-      onChange={onEdit}
-    />
+    <>
+      <CustomToolbar />
+      <ReactQuill
+        style={{ height: "230px", borderBottomLeftRadius: "8px" }}
+        theme="snow"
+        placeholder="메세지를 남겨주세요."
+        modules={modules}
+        formats={formats}
+        value={value}
+        onChange={onEdit}
+      />
+    </>
   );
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
namgyeonglee/feature/add-message-create-page -> main

### 변경 사항

- react-quill tool bar 에서 불필요한 요소 삭제 (indent 등) <code>동혁님 확인 필요</code>
- 유저가 프로필 이미지 선택 안하고 submit 했을 때 POST 안되는 에러 해결 (선택 안하면 default img 부여) <code>동혁님 확인 필요</code>
- form 내 select 태그가 CSS 커스텀 불가능한 문제 -> 재활용 및 CSS 커스텀 가능한 공용 컴포넌트로 제작 (CustomSelect.jsx) <code>나연님 확인 필요</code>
- Input 태그 hover 및 focus 일 때 CSS 추가
- 안쓰는 코드 삭제

### 테스트 결과
- CustomSelect 적용 후에도 유저가 선택한 정보대로 POST 잘 동작합니다. /post/{postId} 페이지 상에 UI 그려지는 것까지 확인했습니다.